### PR TITLE
Change check for partial results (np.isreal -> is not None)

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -244,7 +244,7 @@ if __name__ == "__main__":
                 desc=f"Validating {sample[:20]}...",
             )
             _results = list(_rmap)
-            counts = np.sum([r for r in _results if np.isreal(r)])
+            counts = np.sum([r for r in _results if r is not None])
             all_invalid += [r for r in _results if type(r) == str]
             print("Events:", np.sum(counts))  # noqa
         print("Bad files:")  # noqa


### PR DESCRIPTION
When validating samples with corrupted files it was returning 
```
$ python runner.py --wf dystudies --dump /work/gallim/devel/HiggsDNA_studies/out --executor dask/slurm --meta Era2017_legacy_xgb_v1.json --samples filefetcher/dystudies.json --ts DummyTagger1 DummyTagger2 --worker
s 12 --validate                                                                                                                                                                                                      
Validating DoubleEG-Run2017B...:   0%|                                                                                                                                                        | 0/43 [00:00<?, ?it/s]
Corrupted file: root://cmseos.fnal.gov//store/data/Run2017B/DoubleEG/NANOAOD/UL2017_MiniAODv1_NanoAODv2-v1/280000/CEB7BEBD-9D5C-F045-A84A-0E70924C2BCE.root
Validating DoubleEG-Run2017B...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 43/43 [00:13<00:00,  3.21it/s]
Traceback (most recent call last):
  File "runner.py", line 247, in <module>
    counts = np.sum([r for r in _results if np.isreal(r)])
  File "<__array_function__ internals>", line 6, in sum
  File "/work/gallim/anaconda3/envs/hgg-coffea/lib/python3.7/site-packages/numpy/core/fromnumeric.py", line 2248, in sum
    initial=initial, where=where)
  File "/work/gallim/anaconda3/envs/hgg-coffea/lib/python3.7/site-packages/numpy/core/fromnumeric.py", line 87, in _wrapreduction
    return ufunc.reduce(obj, axis, dtype, out, **passkwargs)
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```
probably because ```np.isnan``` returns ```True``` for ```NoneType``` objects