### PR TITLE
Use parquet categories correctly

### DIFF
--- a/src/hgg_coffea/workflows/base.py
+++ b/src/hgg_coffea/workflows/base.py
@@ -293,7 +293,7 @@ class HggBaseProcessor(processor.ProcessorABC):  # type: ignore
             )
             subdirs = []
             if "dataset" in events.metadata:
-                subdirs.append(events.metadata["dataset"])
+                subdirs.append(f"dataset={events.metadata["dataset"]}")
             self.dump_pandas(df, fname, self.output_location, subdirs)
 
         return histos_etc

--- a/src/hgg_coffea/workflows/base.py
+++ b/src/hgg_coffea/workflows/base.py
@@ -293,7 +293,7 @@ class HggBaseProcessor(processor.ProcessorABC):  # type: ignore
             )
             subdirs = []
             if "dataset" in events.metadata:
-                subdirs.append(f"dataset={events.metadata["dataset"]}")
+                subdirs.append(f'dataset={events.metadata["dataset"]}')
             self.dump_pandas(df, fname, self.output_location, subdirs)
 
         return histos_etc


### PR DESCRIPTION
This lets us use file paths to add information to datasets, for instance:
```
/some/path/to/files/dataset=somename
```
Will add a `dataset` column to the resulting `pandas._read_parquet` where all the files in the `dataset=somename` subdir are labelled with `somename`.

This works for pandas, dask dataframes, apache spark, etc... Pretty convenient.